### PR TITLE
Query inskrivning direkt with objektidentitet

### DIFF
--- a/views/inskrivningerror.handlebars
+++ b/views/inskrivningerror.handlebars
@@ -1,7 +1,7 @@
 <div class="container-fluid">
   <div class="row">
     <div class="col-md-4">
-      <h3>Ogiltig fastighetsnyckel {{fnr}}</h3>
+      <h3>Ogiltig fastighetsreferens {{fid}}</h3>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Adds the ability to query inskrivning direkt with either fastighetsnyckel
`http://localhost:3001/service/estate/inskrivning?fnr=`
or objektidentitet
`http://localhost:3001/service/estate/inskrivning?objektid=`

Query fastighetsinformation with fastighetsnyckel is deprecated