### PR TITLE
Get height for coordinates from Lantmäteriets Höjd Direkt

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,6 @@ Configured services at:
 
 		/origoserver/lmproxy
 
+- Höjd Direkt - set username and password in conf/config.js
+
+    /origoserver/lmelevation/{EPSG code}/{longitude}/{latitude}

--- a/conf/config.js
+++ b/conf/config.js
@@ -28,5 +28,12 @@ module.exports = {
       user: 'xxxxx',
       pass: 'xxxxx'
     }
+  },
+  lmelevation: {
+    url: "https://services.lantmateriet.se/distribution/produkter/hojd/v1/rest/api",
+    auth: {
+      user: 'xxxxx',
+      pass: 'xxxxx'
+    }
   }
 }

--- a/handlers/lmelevation.js
+++ b/handlers/lmelevation.js
@@ -1,0 +1,164 @@
+var conf = require('../conf/config');
+var request = require('request');
+var rp = require('request-promise');
+var proj4 = require('proj4');
+//var Promise = require('bluebird');
+
+var objectIds;
+var username;
+var password;
+var srid;
+var validProjs = ["3006", "3007", "3008", "3009", "3010", "3011", "3012", "3013", "3014", "3015", "3016", "3017", "3018", "3857", "4326"];
+
+proj4.defs([
+  [
+    'EPSG:3006',
+    '+proj=utm +zone=33 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
+  ],
+  [
+    'EPSG:3007',
+    '+proj=tmerc +lat_0=0 +lon_0=12 +k=1 +x_0=150000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
+  ],
+  [
+    'EPSG:3008',
+    '+proj=tmerc +lat_0=0 +lon_0=13.5 +k=1 +x_0=150000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
+  ],
+  [
+    'EPSG:3009',
+    '+proj=tmerc +lat_0=0 +lon_0=15 +k=1 +x_0=150000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
+  ],
+  [
+    'EPSG:3010',
+    '+proj=tmerc +lat_0=0 +lon_0=16.5 +k=1 +x_0=150000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
+  ],
+  [
+    'EPSG:3011',
+    '+proj=tmerc +lat_0=0 +lon_0=18 +k=1 +x_0=150000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
+  ],
+  [
+    'EPSG:3012',
+    '+proj=tmerc +lat_0=0 +lon_0=14.25 +k=1 +x_0=150000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
+  ],
+  [
+    'EPSG:3013',
+    '+proj=tmerc +lat_0=0 +lon_0=15.75 +k=1 +x_0=150000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
+  ],
+  [
+    'EPSG:3014',
+    '+proj=tmerc +lat_0=0 +lon_0=17.25 +k=1 +x_0=150000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
+  ],
+  [
+    'EPSG:3015',
+    '+proj=tmerc +lat_0=0 +lon_0=18.75 +k=1 +x_0=150000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
+  ],
+  [
+    'EPSG:3016',
+    '+proj=tmerc +lat_0=0 +lon_0=20.25 +k=1 +x_0=150000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
+  ],
+  [
+    'EPSG:3017',
+    '+proj=tmerc +lat_0=0 +lon_0=21.75 +k=1 +x_0=150000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
+  ],
+  [
+    'EPSG:3018',
+    '+proj=tmerc +lat_0=0 +lon_0=23.25 +k=1 +x_0=150000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
+  ]
+]);
+
+module.exports = function lmProxy(req, res) {
+  var proxyUrl = 'lmelevation';
+  var options;
+  objectIds = [];
+
+  res.header("Access-Control-Allow-Origin", "*");
+  res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+
+  if (conf[proxyUrl]) {
+    options = Object.assign({}, conf[proxyUrl]);
+
+    prepareRequest(req, res, options, proxyUrl);
+  }
+}
+
+function prepareRequest(req, res, options, proxyUrl) {
+  var buckets;
+  var srid;
+  var xcoord;
+  var ycoord;
+  var urlArr;
+  username = options.auth.user;
+  password = options.auth.pass;
+
+  buckets = decodeURI(req.url.split(proxyUrl));
+  urlArr = req.url.split('/');
+  srid = decodeURI(urlArr[2]);
+  xcoord = decodeURI(urlArr[3]);
+  ycoord = decodeURI(urlArr[4]);
+
+  // Check that request url has numbers
+  if (isNaN(srid) || isNaN(xcoord) || isNaN(ycoord) ) {
+    res.send({ error: 'Request parameters not numbers' });
+  } else {
+    // Check that crs is one of the defined
+    if ( !validProjs.includes(srid) ) {
+      res.send({ error: 'Wrong crs input, must be between 3006 and 3018 or 3857, 4326' });
+    } else {
+      if (srid !== '3006') {
+        var newCoordinates = transformCoordinates(srid, '3006', [Number(xcoord), Number(ycoord)]);
+        xcoord = newCoordinates[0];
+        ycoord = newCoordinates[1];
+      }
+      var optionsRP = {
+          uri: encodeURI(options.url + '/hojd/3006/' + xcoord + '/' + ycoord + '/'),
+          headers: {
+            'User-Agent': 'Origoserver',
+            'content-type': 'application/json',
+            'Authorization': 'Basic ' + Buffer.from(username + ':' + password).toString('base64')
+          },
+          json: true // Automatically parses the JSON string in the response
+      };
+
+      rp(optionsRP)
+      .then(function (parsedBody) {
+        if (srid === '3006') {
+          res.send(parsedBody);
+        } else {
+          res.send(concatResult(parsedBody, srid));
+        }
+      })
+      .catch(function (err) {
+        console.log(err);
+        res.send(undefined);
+        console.log('ERROR1!');
+      });
+    }
+  }
+}
+
+function transformCoordinates(fromProjection, toProjection, coordinates) {
+  return proj4('EPSG:' + fromProjection, 'EPSG:' + toProjection, coordinates);
+}
+
+function concatResult(feature, toProjection) {
+  const result = {};
+
+  const coordinates = feature.geometry.coordinates;
+  const nodatavalue = feature.properties.nodatavalue;
+
+  result['type'] = 'Feature';
+  result['crs'] = {
+    type: 'name',
+    properties:  {
+      name: 'urn:ogc:def:crs:EPSG::' + toProjection
+    }
+  };
+  result['geometry'] = {
+    type: 'Point',
+    coordinates: transformCoordinates('3006', toProjection, coordinates)
+  };
+  result['properties'] = {
+    nodatavalue: nodatavalue
+  };
+
+  return result;
+}

--- a/handlers/lmelevation.js
+++ b/handlers/lmelevation.js
@@ -1,7 +1,7 @@
 var conf = require('../conf/config');
 var request = require('request');
 var rp = require('request-promise');
-var proj4 = require('proj4');
+var transformCoordinates = require('../lib/utils/transformCoordinates');
 //var Promise = require('bluebird');
 
 var objectIds;
@@ -9,61 +9,6 @@ var username;
 var password;
 var srid;
 var validProjs = ["3006", "3007", "3008", "3009", "3010", "3011", "3012", "3013", "3014", "3015", "3016", "3017", "3018", "3857", "4326"];
-
-proj4.defs([
-  [
-    'EPSG:3006',
-    '+proj=utm +zone=33 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
-  ],
-  [
-    'EPSG:3007',
-    '+proj=tmerc +lat_0=0 +lon_0=12 +k=1 +x_0=150000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
-  ],
-  [
-    'EPSG:3008',
-    '+proj=tmerc +lat_0=0 +lon_0=13.5 +k=1 +x_0=150000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
-  ],
-  [
-    'EPSG:3009',
-    '+proj=tmerc +lat_0=0 +lon_0=15 +k=1 +x_0=150000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
-  ],
-  [
-    'EPSG:3010',
-    '+proj=tmerc +lat_0=0 +lon_0=16.5 +k=1 +x_0=150000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
-  ],
-  [
-    'EPSG:3011',
-    '+proj=tmerc +lat_0=0 +lon_0=18 +k=1 +x_0=150000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
-  ],
-  [
-    'EPSG:3012',
-    '+proj=tmerc +lat_0=0 +lon_0=14.25 +k=1 +x_0=150000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
-  ],
-  [
-    'EPSG:3013',
-    '+proj=tmerc +lat_0=0 +lon_0=15.75 +k=1 +x_0=150000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
-  ],
-  [
-    'EPSG:3014',
-    '+proj=tmerc +lat_0=0 +lon_0=17.25 +k=1 +x_0=150000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
-  ],
-  [
-    'EPSG:3015',
-    '+proj=tmerc +lat_0=0 +lon_0=18.75 +k=1 +x_0=150000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
-  ],
-  [
-    'EPSG:3016',
-    '+proj=tmerc +lat_0=0 +lon_0=20.25 +k=1 +x_0=150000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
-  ],
-  [
-    'EPSG:3017',
-    '+proj=tmerc +lat_0=0 +lon_0=21.75 +k=1 +x_0=150000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
-  ],
-  [
-    'EPSG:3018',
-    '+proj=tmerc +lat_0=0 +lon_0=23.25 +k=1 +x_0=150000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
-  ]
-]);
 
 module.exports = function lmProxy(req, res) {
   var proxyUrl = 'lmelevation';
@@ -133,10 +78,6 @@ function prepareRequest(req, res, options, proxyUrl) {
       });
     }
   }
-}
-
-function transformCoordinates(fromProjection, toProjection, coordinates) {
-  return proj4('EPSG:' + fromProjection, 'EPSG:' + toProjection, coordinates);
 }
 
 function concatResult(feature, toProjection) {

--- a/lib/utils/transformcoordinates.js
+++ b/lib/utils/transformcoordinates.js
@@ -1,0 +1,72 @@
+var proj4 = require('proj4');
+
+var transformCoordinates = function transformCoordinates(fromProjection, toProjection, coordinates) {
+  proj4.defs([
+    [
+      'EPSG:3006',
+      '+proj=utm +zone=33 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
+    ],
+    [
+      'EPSG:3007',
+      '+proj=tmerc +lat_0=0 +lon_0=12 +k=1 +x_0=150000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
+    ],
+    [
+      'EPSG:3008',
+      '+proj=tmerc +lat_0=0 +lon_0=13.5 +k=1 +x_0=150000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
+    ],
+    [
+      'EPSG:3009',
+      '+proj=tmerc +lat_0=0 +lon_0=15 +k=1 +x_0=150000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
+    ],
+    [
+      'EPSG:3010',
+      '+proj=tmerc +lat_0=0 +lon_0=16.5 +k=1 +x_0=150000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
+    ],
+    [
+      'EPSG:3011',
+      '+proj=tmerc +lat_0=0 +lon_0=18 +k=1 +x_0=150000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
+    ],
+    [
+      'EPSG:3012',
+      '+proj=tmerc +lat_0=0 +lon_0=14.25 +k=1 +x_0=150000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
+    ],
+    [
+      'EPSG:3013',
+      '+proj=tmerc +lat_0=0 +lon_0=15.75 +k=1 +x_0=150000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
+    ],
+    [
+      'EPSG:3014',
+      '+proj=tmerc +lat_0=0 +lon_0=17.25 +k=1 +x_0=150000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
+    ],
+    [
+      'EPSG:3015',
+      '+proj=tmerc +lat_0=0 +lon_0=18.75 +k=1 +x_0=150000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
+    ],
+    [
+      'EPSG:3016',
+      '+proj=tmerc +lat_0=0 +lon_0=20.25 +k=1 +x_0=150000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
+    ],
+    [
+      'EPSG:3017',
+      '+proj=tmerc +lat_0=0 +lon_0=21.75 +k=1 +x_0=150000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
+    ],
+    [
+      'EPSG:3018',
+      '+proj=tmerc +lat_0=0 +lon_0=23.25 +k=1 +x_0=150000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
+    ]
+  ]);
+
+  // If the projections is the same do nothing otherwise try transform
+  if (fromProjection === toProjection) {
+    return coordinates;
+  } else {
+    try {
+      return proj4('EPSG:' + fromProjection, 'EPSG:' + toProjection, coordinates);
+    } catch (e) {
+      console.error('Error: ' + e);
+      return coordinates;
+    }
+  }
+}
+
+module.exports = transformCoordinates;

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,9 +29,9 @@
       }
     },
     "ajv": {
-      "version": "6.9.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.2.tgz",
-      "integrity": "sha512-4UFy0/LgDo7Oa/+wOAlj44tp9K78u38E5/359eSrqEp1Z5PdVfimCcs7SluXMP755RUQu6d2b4AvF0R1C9RZjg==",
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -73,9 +73,9 @@
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.0.tgz",
+      "integrity": "sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A=="
     },
     "babel-runtime": {
       "version": "5.8.38",
@@ -161,9 +161,9 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "combined-stream": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -551,16 +551,16 @@
       },
       "dependencies": {
         "mime-db": {
-          "version": "1.38.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
-          "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg=="
+          "version": "1.42.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
+          "integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ=="
         },
         "mime-types": {
-          "version": "2.1.22",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
-          "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
+          "version": "2.1.25",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.25.tgz",
+          "integrity": "sha512-5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==",
           "requires": {
-            "mime-db": "~1.38.0"
+            "mime-db": "1.42.0"
           }
         }
       }
@@ -718,8 +718,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "optional": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isstream": {
       "version": "0.1.2",
@@ -763,6 +762,11 @@
         "verror": "1.10.0"
       }
     },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
     "manakin": {
       "version": "0.4.8",
       "resolved": "https://registry.npmjs.org/manakin/-/manakin-0.4.8.tgz",
@@ -783,6 +787,11 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
+    "mgrs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mgrs/-/mgrs-1.0.0.tgz",
+      "integrity": "sha1-+5FYjnjJACVnI5XLQLJffNatGCk="
     },
     "mime": {
       "version": "1.6.0",
@@ -1109,8 +1118,16 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-      "optional": true
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+    },
+    "proj4": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.6.0.tgz",
+      "integrity": "sha512-ll2WyehUFOyzEZtN8hAiOTmZpuDCN5V+4A/HjhPbhlwVwlsFKnIHSZ3l3uhzgDndHjoL2MyERFGe9VmXN4rYUg==",
+      "requires": {
+        "mgrs": "1.0.0",
+        "wkt-parser": "^1.2.0"
+      }
     },
     "promise": {
       "version": "8.0.2",
@@ -1130,9 +1147,9 @@
       }
     },
     "psl": {
-      "version": "1.1.31",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.6.0.tgz",
+      "integrity": "sha512-SYKKmVel98NCOYXpkwUqZqh0ahZeeKfmisiLIcEZdsb+WbLv02g/dI5BUmZnIyOe7RzZtLax81nnb2HbvC2tzA=="
     },
     "punycode": {
       "version": "2.1.1",
@@ -1162,7 +1179,6 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-      "optional": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -1201,16 +1217,16 @@
       },
       "dependencies": {
         "mime-db": {
-          "version": "1.38.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
-          "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg=="
+          "version": "1.42.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
+          "integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ=="
         },
         "mime-types": {
-          "version": "2.1.22",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
-          "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
+          "version": "2.1.25",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.25.tgz",
+          "integrity": "sha512-5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==",
           "requires": {
-            "mime-db": "~1.38.0"
+            "mime-db": "1.42.0"
           }
         },
         "qs": {
@@ -1218,6 +1234,25 @@
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
           "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
         }
+      }
+    },
+    "request-promise": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.5.tgz",
+      "integrity": "sha512-ZgnepCykFdmpq86fKGwqntyTiUrHycALuGggpyCZwMvGaZWgxW6yagT0FHkgo5LzYvOaCNvxYwWYIjevSH1EDg==",
+      "requires": {
+        "bluebird": "^3.5.0",
+        "request-promise-core": "1.1.3",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
+      "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
+      "requires": {
+        "lodash": "^4.17.15"
       }
     },
     "requires-port": {
@@ -1393,11 +1428,15 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+    },
     "string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "optional": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -1503,8 +1542,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "optional": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -1512,9 +1550,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
     },
     "vary": {
       "version": "1.1.2",
@@ -1530,6 +1568,11 @@
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
       }
+    },
+    "wkt-parser": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.2.3.tgz",
+      "integrity": "sha512-s7zrOedGuHbbzMaQOuf8HacuCYp3LmmrHjkkN//7UEAzsYz7xJ6J+j/84ZWZkQcrRqi3xXyuc4odPHj7PEB0bw=="
     },
     "wordwrap": {
       "version": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "express": "^4.17.1",
     "express-handlebars": "^3.0.0",
     "http-proxy": "^1.17.0",
-    "request": "^2.74.0",
+    "proj4": "^2.6.0",
+    "request": "^2.88.0",
+    "request-promise": "^4.2.5",
     "serve-favicon": "^2.5.0",
     "xml2js": "^0.4.17",
     "xmlbuilder": "^8.2.2"

--- a/routes/index.js
+++ b/routes/index.js
@@ -10,6 +10,7 @@ var proxy = require('../handlers/proxy');
 var lmProxy = require('../handlers/lmproxy');
 var lmProxyVer = require('../handlers/lmproxyver');
 var getAkt = require('../handlers/getakt');
+var lmElevation = require('../handlers/lmelevation');
 
 /* GET start page. */
 router.get('/', function (req, res) {
@@ -24,5 +25,6 @@ router.all('/proxy', proxy);
 router.all('/lmproxy/*', lmProxy);
 router.all('/lmproxy-ver/*', lmProxyVer);
 router.all('/document/*', getAkt);
+router.all('/lmelevation*', lmElevation);
 
 module.exports = router;


### PR DESCRIPTION
Acts almost like a proxy for Höjd Direkt with the addition that it also can convert coordinates since the original service only supports SWEREF99 TM.

![image](https://user-images.githubusercontent.com/48793206/70620439-9651f300-1c17-11ea-9d79-d1e96c53c20e.png)
