### PR TITLE
Add search option `useCentroid` to allow full feature geometry

### DIFF
--- a/conf/dbconfig.js
+++ b/conf/dbconfig.js
@@ -45,13 +45,15 @@ module.exports = {
           //     table: "table name",
           //     searchField: "search field name",
           //     schema: 'schema name, for example dbo',
-          //     database: 'database name'
+          //     database: 'database name',
+          //     useCentroid: true
           // }
           search: {
               table: "fastighetsytor_sammanslagen",
               searchField: "FASTIGHET",
               schema: 'public',
               geometryName: 'geom',
+              useCentroid: true
           }
 
       },
@@ -62,7 +64,8 @@ module.exports = {
               schema: 'public',
               geometryName: 'geom',
               database: 'mdk',
-			  tables: [
+              useCentroid: true,
+              tables: [
 				  {
 					table: 'adressplats',
 					searchField: 'NAMN'
@@ -84,6 +87,7 @@ module.exports = {
               searchField: "search field name",
               schema: 'schema name, for example dbo',
               database: 'database name',
+              useCentroid: true,
               fields: ['field name', 'field name']
           },
           estates: {
@@ -91,6 +95,7 @@ module.exports = {
               searchField: "search field name",
               schema: 'schema name, for example dbo',
               database: 'database name',
+              useCentroid: true,
               fields: ['field name', 'field name']
           }
       }

--- a/models/mssqldefault.js
+++ b/models/mssqldefault.js
@@ -6,7 +6,9 @@ var mssqlDefault = function mssqlDefault(queryString, queryOptions, defaultLimit
   var sqlSearchField = searchField ? searchField + " AS NAMN," : "";
   var fields = queryOptions.fields;
   var geometryField = queryOptions.geometryName || "geom";
-  var centroid = geometryField + ".STPointOnSurface().ToString() AS GEOM " + " ";
+  var useCentroid = queryOptions.hasOwnProperty("useCentroid") ? queryOptions.useCentroid : true;
+  var wkt = useCentroid ? geometryField + ".STPointOnSurface().ToString() AS GEOM " + " " :
+    geometryField + ".ToString() AS GEOM " + " ";
   var sqlFields = fields ? fields.join(',') + "," : "";
   var type = " '" + table + "'" + " AS TYPE, ";
   var condition = queryString;
@@ -16,7 +18,7 @@ var mssqlDefault = function mssqlDefault(queryString, queryOptions, defaultLimit
 
   searchString =
     "SELECT " + limit +
-    sqlSearchField + sqlFields + type + centroid +
+    sqlSearchField + sqlFields + type + wkt +
     " FROM " + database + "." + schema + "." + table +
     " WHERE LOWER(" + searchField + ") LIKE LOWER('" + condition + "%')" + " " +
     " ORDER BY " + searchField + "";

--- a/models/oracledefault.js
+++ b/models/oracledefault.js
@@ -5,6 +5,9 @@ var oracleDefault = function oracleDefault(queryString, queryOptions) {
   var sqlSearchField = searchField ? searchField + " AS NAMN," : "";
   var fields = queryOptions.fields;
   var geometryField = queryOptions.geometryName || "geom";
+  var useCentroid = queryOptions.hasOwnProperty("useCentroid") ? queryOptions.useCentroid : true;
+  var wkt = useCentroid ? "TO_CHAR(SDO_UTIL.TO_WKTGEOMETRY(SDO_GEOM.SDO_CENTROID(" + geometryField + ", m.diminfo))) AS GEOM" :
+    "TO_CHAR(SDO_UTIL.TO_WKTGEOMETRY(" + geometryField + ")) AS GEOM";
   var sqlFields = fields ? fields.join(',') + "," : "";
   var condition = queryString;
   var searchString;
@@ -18,7 +21,7 @@ var oracleDefault = function oracleDefault(queryString, queryOptions) {
 
   searchString =
     "SELECT " + sqlSearchField + sqlFields + "'" + table + "'" + " AS type," +
-    "TO_CHAR(SDO_UTIL.TO_WKTGEOMETRY(SDO_GEOM.SDO_CENTROID(" + geometryField + ", m.diminfo))) AS GEOM" + " " +
+    wkt + " " +
     "FROM " + schema + "." + table + ", user_sdo_geom_metadata m " +
     "WHERE " + sdo_geom_metadata + "' AND lower(" + searchField + ") LIKE lower('" + condition + "%')" + " " +
     "ORDER BY " + searchField + "";

--- a/models/pgdefault.js
+++ b/models/pgdefault.js
@@ -6,7 +6,9 @@ var pgDefault = function pgDefault(queryString, queryOptions, defaultLimit) {
   var sqlSearchField = searchField ? table + '."' + searchField + '" AS "NAMN",' : "";
   var fields = queryOptions.fields;
   var geometryField = queryOptions.geometryName || "geom";
-  var centroid = 'ST_AsText(ST_PointOnSurface(' + table + '."' + geometryField + '")) AS "GEOM" ';
+  var useCentroid = queryOptions.hasOwnProperty("useCentroid") ? queryOptions.useCentroid : true;
+  var wkt = useCentroid ? 'ST_AsText(ST_PointOnSurface(' + table + '."' + geometryField + '")) AS "GEOM" ' :
+    'ST_AsText(' + table + '."' + geometryField + '") AS "GEOM" ';
   var sqlFields = fields ? fields.join(',') + "," : "";
   var type = " '" + table + "'" + ' AS "TYPE", ';
   var condition = queryString;
@@ -19,7 +21,7 @@ var pgDefault = function pgDefault(queryString, queryOptions, defaultLimit) {
     sqlSearchField +
     ' ' + table + '."' + gid + '" AS "GID", ' +
     type +
-    centroid +
+    wkt +
     ' FROM ' + schema + '.' + table +
     ' WHERE LOWER(' + table + '."' + searchField + '"' + ") ILIKE LOWER('" + condition + "%')" +
     ' ORDER BY ' + table + '."' + searchField + '"' +


### PR DESCRIPTION
Fixes #52.

Added a new option `useCentroid` (expects boolean) to `conf\dbconfig.js` search models that controls whether or not the geometries in the response will be converted to their centroids.

The geometry variables in the `models\...default.js` have been renamed from `centroid` to `wkt` to reflect this. In `models\oracledefault.js` the `wkt` variable was added so that the structure aligns with `mssqldefault.js` and `pgdefault.js`.

The `wkt` variable will default to using the centroid if the `useCentroid` option is missing.