### PR TITLE
Adds sqlFields to SQL query in models/pgdefault.js

### DIFF
--- a/models/pgdefault.js
+++ b/models/pgdefault.js
@@ -18,6 +18,7 @@ var pgDefault = function pgDefault(queryString, queryOptions, defaultLimit) {
     'SELECT ' +
     sqlSearchField +
     ' ' + table + '."' + gid + '" AS "GID", ' +
+    sqlFields +
     type +
     centroid +
     ' FROM ' + schema + '.' + table +


### PR DESCRIPTION
Fixes #54.

The `sqlFields` variable is [already defined](https://github.com/origo-map/origo-server/blob/d902e57b2c1d3b9ed0439e0521439965e7dd16d5/models/pgdefault.js#L10) in the model, but never used. This commit adds it to the model's query so that fields from the `fields: []` option given in [`conf/dbconfig.js`](https://github.com/origo-map/origo-server/blob/master/conf/dbconfig.js) are returned in the search result as they would be with the other database models.