### PR TITLE
fix: introduce case sensitivity for search pg table names

### DIFF
--- a/models/pgdefault.js
+++ b/models/pgdefault.js
@@ -3,12 +3,12 @@ var pgDefault = function pgDefault(queryString, queryOptions, defaultLimit) {
   var table = queryOptions.table;
   var searchField = queryOptions.searchField;
   var gid = queryOptions.gid || 'gid';
-  var sqlSearchField = searchField ? 'CAST(' + table + '."' + searchField + '" AS TEXT) AS "NAMN",' : "";
+  var sqlSearchField = searchField ? 'CAST("' + table + '"."' + searchField + '" AS TEXT) AS "NAMN",' : "";
   var fields = queryOptions.fields;
   var geometryField = queryOptions.geometryName || "geom";
   var useCentroid = queryOptions.hasOwnProperty("useCentroid") ? queryOptions.useCentroid : true;
   var wkt = useCentroid ? 'ST_AsText(ST_PointOnSurface(' + table + '."' + geometryField + '")) AS "GEOM" ' :
-    'ST_AsText(' + table + '."' + geometryField + '") AS "GEOM" ';
+    'ST_AsText("' + table + '"."' + geometryField + '") AS "GEOM" ';
   var sqlFields = fields ? fields.join(',') + "," : "";
   var type = " '" + table + "'" + ' AS "TYPE", ';
   var condition = queryString;
@@ -19,13 +19,13 @@ var pgDefault = function pgDefault(queryString, queryOptions, defaultLimit) {
   searchString =
     'SELECT ' +
     sqlSearchField +
-    ' ' + table + '."' + gid + '" AS "GID", ' +
+    ' "' + table + '"."' + gid + '" AS "GID", ' +
     sqlFields +
     type +
     wkt +
-    ' FROM ' + schema + '.' + table +
-    ' WHERE LOWER(CAST(' + table + '."' + searchField + '"' + " AS TEXT)) ILIKE LOWER('" + condition + "%')" +
-    ' ORDER BY ' + table + '."' + searchField + '"' +
+    ' FROM ' + schema + '."' + table + '"' +
+    ' WHERE LOWER(CAST("' + table + '"."' + searchField + '"' + " AS TEXT)) ILIKE LOWER('" + condition + "%')" +
+    ' ORDER BY "' + table + '"."' + searchField + '"' +
     limit + ';';
 
   return searchString;


### PR DESCRIPTION
Fixes #89 but/and introduces case sensitivity for search table names. Which is to say both schema."Lansstyrelsen_Sjogull" and schema.lansstyrelsen_sjogull can now be expected to return search results without the first returning search hits with escaped double quotation marks and causing trouble for the Origo client. This also means that if dbconfig.js for search wants to use a table called schema.testar_poly_origo it can no longer be written as  
 table: 'Testar_poly_origo', but rather must be written as  table: 'testar_poly_origo'
Edit. This makes the table name consistent with the column names as they are case sensitive in dbconfig.js today