### PR TITLE
Proxy for LM API

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,6 +5,7 @@ var cors = require('cors');
 const rateLimit = require('express-rate-limit');
 
 var routes = require('./routes/index');
+//const lmApiProxy = require('./routes/lmapiproxy');
 var mapStateRouter = require('./routes/mapstate');
 var errors = require('./routes/errors');
 var conf = require('./conf/config');
@@ -81,6 +82,7 @@ if (conf['cors']) {
 
 app.use('/origoserver/', routes);
 app.use('/mapstate', mapStateRouter);
+//app.use('/lmapiproxy', lmApiProxy(conf['lmapiproxy']));
 app.use(errors);
 
 module.exports = app;

--- a/conf/config.js
+++ b/conf/config.js
@@ -32,6 +32,14 @@ module.exports = {
       pass: 'xxxxx'
     }
   },
+  lmapiproxy: {
+    url: 'https://api.lantmateriet.se/',
+    url_token: "https://api.lantmateriet.se/token",
+    url_revoke: "https://api.lantmateriet.se/revoke",
+    consumer_key: 'xxxxx',
+    consumer_secret: 'xxxxx',
+    scope: 'am_application_scope default'
+  },
   lmbuilding: {
     url: 'https://api.lantmateriet.se/distribution/produkter/byggnad/v2',
     url_token: "https://api.lantmateriet.se/token",

--- a/package-lock.json
+++ b/package-lock.json
@@ -265,6 +265,21 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
       "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
     },
+    "axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "requires": {
+        "follow-redirects": "^1.14.8"
+      },
+      "dependencies": {
+        "follow-redirects": {
+          "version": "1.14.9",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+          "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
+        }
+      }
+    },
     "babel-runtime": {
       "version": "5.8.38",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
@@ -779,6 +794,11 @@
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
       "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA=="
     },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -1018,6 +1038,26 @@
         }
       }
     },
+    "express-http-proxy": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/express-http-proxy/-/express-http-proxy-1.6.3.tgz",
+      "integrity": "sha512-/l77JHcOUrDUX8V67E287VEUQT0lbm71gdGVoodnlWBziarYKgMcpqT7xvh/HM8Jv52phw8Bd8tY+a7QjOr7Yg==",
+      "requires": {
+        "debug": "^3.0.1",
+        "es6-promise": "^4.1.1",
+        "raw-body": "^2.3.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
     "express-normalize-query-params-middleware": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/express-normalize-query-params-middleware/-/express-normalize-query-params-middleware-0.5.1.tgz",
@@ -1034,9 +1074,9 @@
       }
     },
     "express-rate-limit": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-6.2.0.tgz",
-      "integrity": "sha512-q9xfttbPX79HiBsHA4LT3PZEeJR96CJ5/2jloAKSEECMx8XlOOOpjxx6iK/kBw3hFJ8uhx6Q9lCfSGp70yV0tQ=="
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-6.3.0.tgz",
+      "integrity": "sha512-932Io1VGKjM3ppi7xW9sb1J5nVkEJSUiOtHw2oE+JyHks1e+AXuOBSXbJKM0mcXwEnW1TibJibQ455Ow1YFjfg=="
     },
     "extend": {
       "version": "3.0.2",
@@ -5343,9 +5383,9 @@
       }
     },
     "oracledb": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/oracledb/-/oracledb-3.1.2.tgz",
-      "integrity": "sha512-DOBKpUlfvGAX6bcpuPGtPVVfOOUqFue8eLjbnnmkDyBTU+YuH+gXHRy4ftlFzkHBXYkrSGenFJrXy8dDfEVXCg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/oracledb/-/oracledb-5.3.0.tgz",
+      "integrity": "sha512-HMJzQ6lCf287ztvvehTEmjCWA21FQ3RMvM+mgoqd4i8pkREuqFWO+y3ovsGR9moJUg4T0xjcwS8rl4mggWPxmg==",
       "optional": true
     },
     "orm": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start": "node app.js"
   },
   "dependencies": {
+    "axios": "^0.26.1",
     "bluebird": "^3.7.2",
     "body-parser": "^1.19.0",
     "cookie-parser": "~1.3.3",
@@ -21,6 +22,7 @@
     "express": "^4.17.1",
     "express-fileupload": "^1.2.1",
     "express-handlebars": "^5.3.0",
+    "express-http-proxy": "^1.6.3",
     "express-openapi": "^7.5.0",
     "express-rate-limit": "^6.2.0",
     "http-proxy": "^1.18.1",
@@ -45,7 +47,7 @@
     "mssql": "^3.3.0",
     "mysql": "^2.18.1",
     "node-windows": "^0.1.14",
-    "oracledb": "^3.1.2",
+    "oracledb": "^5.3.0",
     "pg": "^8.7.1",
     "pg-promise": "^10.11.1"
   }

--- a/routes/lmapiproxy.js
+++ b/routes/lmapiproxy.js
@@ -1,0 +1,74 @@
+const axios = require('axios').default;
+const proxy = require('express-http-proxy');
+
+const lmApiProxy = function(proxyOptions) {
+  let tokenObject = {};
+  return proxy(proxyOptions.url, {
+    https: true,
+    proxyReqOptDecorator: async (proxyReqOpts, srcReq) => {
+      tokenObject = await getToken(proxyOptions, tokenObject);
+      proxyReqOpts.headers['Authorization'] = `Bearer ${tokenObject.token}`;
+      return proxyReqOpts;
+    }
+  })
+}
+
+async function revokeToken(proxyOptions, tokenObject) {
+  return new Promise((resolve, reject) => {
+    axios({
+        url: proxyOptions.url_revoke,
+        method: 'POST',
+        headers: {
+          'Authorization': 'Basic ' + Buffer.from(proxyOptions.consumer_key + ':' + proxyOptions.consumer_secret).toString('base64')
+        },
+        params: {
+          'scope': proxyOptions.scope,
+          'token': tokenObject.token
+        }
+      })
+      .then(response => {
+        resolve();
+      }).catch(err => {
+        console.log(err);
+        reject('Promise is rejected');
+      })
+  })
+}
+
+async function createToken(proxyOptions) {
+  return new Promise((resolve, reject) => {
+    axios({
+        url: proxyOptions.url_token,
+        method: 'POST',
+        headers: {
+          'Authorization': 'Basic ' + Buffer.from(proxyOptions.consumer_key + ':' + proxyOptions.consumer_secret).toString('base64')
+        },
+        params: {
+          'scope': proxyOptions.scope,
+          'grant_type': 'client_credentials'
+        }
+      })
+      .then(response => {
+        resolve({
+          token: response.data.access_token,
+          tokenExpires: Math.floor(Date.now() / 1000) + response.data.expires_in - 10
+        });
+      }).catch(err => {
+        console.log(err);
+        reject('Promise is rejected');
+      })
+  })
+}
+
+async function getToken(proxyOptions, tokenObject) {
+  if (!tokenObject.tokenExpires || Math.floor(Date.now() / 1000) > tokenObject.tokenExpires) {
+    if (tokenObject.tokenExpires && Math.floor(Date.now() / 1000) > tokenObject.tokenExpires) {
+      await revokeToken(proxyOptions, tokenObject)
+    }
+    const newTokenObject = await createToken(proxyOptions);
+    return newTokenObject;
+  }
+  return tokenObject;
+}
+
+module.exports = lmApiProxy;


### PR DESCRIPTION
Fixes #114 

Add
`const lmApiProxy = require('./routes/lmapiproxy');`

and
`app.use('/lmapiproxy', lmApiProxy(conf['lmapiproxy']));`

in app.js to enable it.

in config.js:

```
  lmapiproxy: {
    url: 'https://api.lantmateriet.se/',
    url_token: "https://api.lantmateriet.se/token",
    url_revoke: "https://api.lantmateriet.se/revoke",
    consumer_key: 'xxxxx',
    consumer_secret: 'xxxxx',
    scope: 'am_application_scope default'
  },
```

It is possible to add multiple proxys with different configs, eg to use both production and verification applications. 

Requests are then made like this:

`localhost:3001/lmapiproxy/distribution/geodatakatalog/visning/v1/detaljplan/v1/wms?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&BBOX=155796.0996650331363,6586605.927696125582,156491.2063119694067,6587395.732860973105&SRS=EPSG:3008&WIDTH=712&HEIGHT=809&LAYERS=detaljplan&STYLES=&FORMAT=image/png&DPI=96&MAP_RESOLUTION=96&FORMAT_OPTIONS=dpi:96&TRANSPARENT=TRUE`
